### PR TITLE
Support 1.20.6

### DIFF
--- a/abstraction/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil.java
+++ b/abstraction/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil.java
@@ -181,14 +181,15 @@ public interface ChipUtil {
     static String bukkitToCraftBukkit() {
         String bukkit = Bukkit.getServer().getBukkitVersion().split("-")[0];
         switch (bukkit) {
-            case "1.20.1": 
+            case "1.20.1":
                 return "1_20_R1";
-            case "1.20.2": 
+            case "1.20.2":
                 return "1_20_R2";
             case "1.20.3":
             case "1.20.4":
                 return "1_20_R3";
             case "1.20.5":
+            case "1.20.6":
                 return "1_20_R4";
             default:
                 throw new AssertionError("Invalid Version: " + bukkit);


### PR DESCRIPTION
## Info
This PR fixes support for 1.20.6.

## Details
Previously, attempting to use MobChip on 1.20.6 would result in an error message like this:
```
[12:48:48 ERROR]: Could not pass event InventoryClickEvent to [...]
java.lang.AssertionError: Invalid Version: 1.20.6
        at [...].mobchip.abstraction.ChipUtil.bukkitToCraftBukkit(ChipUtil.java:194)
```
Since 1.20.5 and 1.20.6 are nearly identical under the hood, simply adding a "1.20.6" case to the switch statement adds support for it.

## Tested Environments

### OS
OS: Debian 12

### Java / Minecraft

#### MC Builds
- [ ] Tested on Latest Spigot Version
- [X] Tested on Latest Paper / Purpur Version

#### JDK Builds
Tested on:
- [ ] JDK Version 8/11
- [ ] JDK Version 17/18
- [X] JDK Version 21
